### PR TITLE
Add size handling for FLUX image generation models

### DIFF
--- a/openai_forward/flux/bfl_api.py
+++ b/openai_forward/flux/bfl_api.py
@@ -6,6 +6,7 @@ import json
 import base64
 import os
 import time
+from math import gcd
 
 BASE_URL = "https://api.bfl.ml/"
 BFL_API_KEY = os.environ.get("BFL_API_KEY", None)
@@ -21,6 +22,31 @@ JSON_SUFFIX = f'''
     ]
 }}
 '''
+
+
+def _clamp_dimensions(width: int, height: int) -> tuple[int, int]:
+    """Clamp dimensions to FLUX 1.1 Pro constraints while preserving aspect ratio."""
+    MIN_DIM = 256
+    MAX_DIM = 1440
+
+    # Scale down if either dimension exceeds max
+    if width > MAX_DIM or height > MAX_DIM:
+        scale = min(MAX_DIM / width, MAX_DIM / height)
+        width = int(width * scale)
+        height = int(height * scale)
+
+    # Scale up if either dimension is below min
+    if width < MIN_DIM or height < MIN_DIM:
+        scale = max(MIN_DIM / width, MIN_DIM / height)
+        width = int(width * scale)
+        height = int(height * scale)
+
+    # Round to nearest multiple of 32
+    width = max(MIN_DIM, min(MAX_DIM, round(width / 32) * 32))
+    height = max(MIN_DIM, min(MAX_DIM, round(height / 32) * 32))
+
+    return width, height
+
 
 class FluxBase:
     API_ENDPOINT = ""
@@ -57,12 +83,29 @@ class FluxBase:
     @classmethod
     async def _image_request(cls, request: Request, headers):
         data = await request.json()
+
+        # Parse size from OpenAI format (e.g., "1024x1024") or use defaults
+        width = 1024
+        height = 1024
+        size = data.get('size')
+        if size and 'x' in size:
+            try:
+                width, height = map(int, size.split('x'))
+            except (ValueError, TypeError):
+                pass  # Use defaults if parsing fails
+
+        # Clamp dimensions to FLUX 1.1 Pro constraints while preserving aspect ratio
+        original_size = f"{width}x{height}"
+        width, height = _clamp_dimensions(width, height)
+
         body = {
             "prompt": data.get('prompt'),
-            "width": 1024,
-            "height": 1024,
+            "width": width,
+            "height": height,
             "prompt_upsampling": True
         }
+
+        logger.info(f"FLUX image generation: endpoint={cls.API_ENDPOINT}, requested={original_size}, actual={width}x{height}")
 
         async with httpx.AsyncClient(base_url=BASE_URL, http1=True, http2=False) as client:
             url = httpx.URL(path=cls.API_ENDPOINT, query=request.url.query.encode("utf-8"))
@@ -234,6 +277,74 @@ class FluxKontextGen(FluxBase):
     API_ENDPOINT = "v1/flux-kontext-pro"
     POLL_ENDPOINT = "v1/get_result"
     ACCEPT = "application/json"
+
+    @classmethod
+    async def _image_request(cls, request: Request, headers):
+        data = await request.json()
+
+        # Parse size and convert to aspect ratio
+        width, height = 1024, 1024
+        size = data.get('size')
+        if size and 'x' in size:
+            try:
+                width, height = map(int, size.split('x'))
+            except (ValueError, TypeError):
+                pass
+
+        # Calculate aspect ratio string (e.g., "16:9")
+        divisor = gcd(width, height)
+        aspect_ratio = f"{width // divisor}:{height // divisor}"
+
+        logger.info(f"FLUX Kontext image generation: endpoint={cls.API_ENDPOINT}, size={width}x{height}, aspect_ratio={aspect_ratio}")
+
+        body = {
+            "prompt": data.get('prompt'),
+            "aspect_ratio": aspect_ratio,
+            "prompt_upsampling": True
+        }
+
+        async with httpx.AsyncClient(base_url=BASE_URL, http1=True, http2=False) as client:
+            url = httpx.URL(path=cls.API_ENDPOINT, query=request.url.query.encode("utf-8"))
+
+            req = client.build_request(
+                request.method,
+                url,
+                headers=headers,
+                content=json.dumps(body),
+                timeout=cls.TIMEOUT,
+            )
+
+            try:
+                r = await client.send(req, stream=False)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+                error_info = (
+                    f"{type(e)}: {e} | "
+                    f"Please check if host={request.client.host} can access [{BASE_URL}] successfully?"
+                )
+                logger.error(error_info)
+                raise HTTPException(
+                    status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail=error_info
+                )
+            except Exception as e:
+                logger.exception(f"{type(e)}:")
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=e
+                )
+
+            if r.status_code != 200:
+                logger.exception(f"{r.status_code}:{r.json()}")
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Error from Flux Kontext call: {r.status_code}"
+                )
+
+            imageId = r.json().get('id')
+            if imageId is None:
+                logger.exception("No Image ID returned from FLUX Kontext")
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY, detail=f"No id returned"
+                )
+
+            return imageId
 
 
 class FluxKontext(FluxBase):


### PR DESCRIPTION
- FLUX 1.1 Pro: Pass through width/height from requests, clamping to API constraints (256-1440px, multiples of 32) while preserving aspect ratio
- FLUX.1 Kontext Gen: Convert width/height to aspect ratio string (e.g., "1792x1024" → "7:4") since Kontext API expects aspect_ratio
- FLUX.1 Kontext Edit: Unchanged, continues using aspect_ratio: None
- Add logging to show requested vs actual dimensions/aspect ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)