### PR TITLE
Add User-Agent whitelist/blacklist filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ Key environment variables (can be set in `.env` file):
 - `FORWARD_KEY`: Space-separated custom keys for API access
 - `ROUTE_PREFIX`: Custom route prefix
 - `LOG_CHAT`: Enable chat logging (true/false)
-- `IP_WHITELIST`/`IP_BLACKLIST`: IP access control
+- `IP_WHITELIST`/`IP_BLACKLIST`: IP access control (space-separated)
+- `UA_WHITELIST`/`UA_BLACKLIST`: User-Agent access control (comma-separated glob patterns, e.g. `UA_WHITELIST="okhttp/3.9.*"` with `UA_BLACKLIST="okhttp/*"`). Whitelist match allows, then blacklist match blocks, otherwise allowed; add `*` to the blacklist for strict whitelist-only mode. Patterns must match the full UA string (case-insensitive). When either list is set, requests with a missing/empty User-Agent are blocked. Blocked requests get a generic 403 identical to the HMAC-failure response (no hint that UA filtering exists).
 
 ## Testing Notes
 

--- a/openai_forward/__main__.py
+++ b/openai_forward/__main__.py
@@ -16,6 +16,8 @@ class Cli:
         route_prefix=None,
         ip_whitelist=None,
         ip_blacklist=None,
+        ua_whitelist=None,
+        ua_blacklist=None,
         app_secret=None,
     ):
         """Run forwarding serve.
@@ -32,6 +34,8 @@ class Cli:
         route_prefix: str, None
         ip_whitelist: str, None
         ip_blacklist: str, None
+        ua_whitelist: str, None  comma-separated glob patterns, e.g. "okhttp/3.9.*"
+        ua_blacklist: str, None  comma-separated glob patterns, e.g. "okhttp/*"
         app_secret: str, None
         """
         if base_url:
@@ -48,6 +52,10 @@ class Cli:
             os.environ["IP_WHITELIST"] = ip_whitelist
         if ip_blacklist:
             os.environ["IP_BLACKLIST"] = ip_blacklist
+        if ua_whitelist:
+            os.environ["UA_WHITELIST"] = ua_whitelist
+        if ua_blacklist:
+            os.environ["UA_BLACKLIST"] = ua_blacklist
         if app_secret:
             os.environ["APP_SECRET"] = app_secret
 

--- a/openai_forward/base.py
+++ b/openai_forward/base.py
@@ -13,6 +13,8 @@ from .tool import env2list
 
 import hmac
 import hashlib
+import fnmatch
+import re
 
 from .routers.image_gen_platform import ImageGenPlatform, ImageEditPlatform
 from .flux.bfl_api import FluxPro11, FluxKontextGen, FluxKontext, ContentModerationError
@@ -47,6 +49,9 @@ class OpenaiBase:
     _no_auth_mode = _openai_api_key_list != [] and _FWD_KEYS == set()
     IP_WHITELIST = env2list("IP_WHITELIST", sep=" ")
     IP_BLACKLIST = env2list("IP_BLACKLIST", sep=" ")
+    # Comma-separated glob patterns (e.g. "okhttp/3.9.*"); comma because UA strings contain spaces
+    UA_WHITELIST = env2list("UA_WHITELIST", sep=",")
+    UA_BLACKLIST = env2list("UA_BLACKLIST", sep=",")
     APP_SECRET = os.environ.get("APP_SECRET", "").strip()
     _IMAGE_GEN_PLATFORMS_STR = os.environ.get("IMAGE_GEN_PLATFORM", "dalle3").strip()
     _IMAGE_EDIT_PLATFORMS_STR = os.environ.get("IMAGE_EDIT_PLATFORM", "openai").strip()
@@ -72,6 +77,31 @@ class OpenaiBase:
     if _LOG_CHAT:
         setting_log(save_file=False)
         chatsaver = ChatSaver()
+
+    @classmethod
+    def _compile_ua_patterns(cls):
+        cls._ua_whitelist_patterns = [
+            re.compile(fnmatch.translate(p), re.IGNORECASE) for p in cls.UA_WHITELIST
+        ]
+        cls._ua_blacklist_patterns = [
+            re.compile(fnmatch.translate(p), re.IGNORECASE) for p in cls.UA_BLACKLIST
+        ]
+
+    def validate_request_user_agent(self, user_agent: str):
+        # detail must stay identical to the HMAC-failure response so blocked
+        # clients can't tell which gate rejected them
+        forbidden = HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+        if not user_agent:
+            logger.info("UA filter: blocked request with missing User-Agent")
+            raise forbidden
+        if any(p.match(user_agent) for p in self._ua_whitelist_patterns):
+            return
+        if any(p.match(user_agent) for p in self._ua_blacklist_patterns):
+            logger.info(f"UA filter: blocked user-agent={user_agent!r}")
+            raise forbidden
 
     def validate_request_host(self, request: Request):
         ip = request.client.host
@@ -405,3 +435,6 @@ class OpenaiBase:
             else r.aiter_bytes()
         )
         return aiter_bytes, r.status_code, r.headers.get("content-type"), BackgroundTask(r.aclose)
+
+
+OpenaiBase._compile_ua_patterns()

--- a/openai_forward/openai.py
+++ b/openai_forward/openai.py
@@ -10,10 +10,13 @@ class Openai(OpenaiBase):
             self.validate_host = True
         else:
             self.validate_host = False
+        self.validate_ua = bool(self.UA_WHITELIST or self.UA_BLACKLIST)
 
     async def reverse_proxy(self, request: Request):
         if self.validate_host:
             self.validate_request_host(request)
+        if self.validate_ua:
+            self.validate_request_user_agent(request.headers.get("user-agent", ""))
         return await self._reverse_proxy(request)
 
     async def v1_chat_completions(self, data: OpenAIV1ChatCompletion, request: Request):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,9 @@ class TestOpenai:
     def teardown_method():
         OpenaiBase.IP_BLACKLIST = []
         OpenaiBase.IP_WHITELIST = []
+        OpenaiBase.UA_BLACKLIST = []
+        OpenaiBase.UA_WHITELIST = []
+        OpenaiBase._compile_ua_patterns()
         OpenaiBase._default_api_key_list = []
 
     def test_env(self, openai: OpenaiBase):
@@ -44,3 +47,50 @@ class TestOpenai:
         assert openai.validate_request_host(ip2) is None
         with pytest.raises(HTTPException):
             openai.validate_request_host(ip1)
+
+    def test_validate_user_agent(self, openai: OpenaiBase):
+        my_app_ua = "okhttp/3.9.3"
+        bad_ua = "okhttp/5.0.0-alpha.2"
+        browser_ua = "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36"
+
+        # no lists configured -> nothing matches, everything passes
+        assert openai.validate_request_user_agent(browser_ua) is None
+
+        # blacklist alone
+        OpenaiBase.UA_BLACKLIST = ["okhttp/*"]
+        OpenaiBase._compile_ua_patterns()
+        with pytest.raises(HTTPException) as exc_info:
+            openai.validate_request_user_agent(bad_ua)
+        # response must not hint at the reason for the block
+        assert exc_info.value.detail == "Forbidden"
+        assert openai.validate_request_user_agent(browser_ua) is None
+
+        # whitelist overrides blacklist
+        OpenaiBase.UA_WHITELIST = ["okhttp/3.9.*"]
+        OpenaiBase._compile_ua_patterns()
+        assert openai.validate_request_user_agent(my_app_ua) is None
+        with pytest.raises(HTTPException):
+            openai.validate_request_user_agent(bad_ua)
+        assert openai.validate_request_user_agent(browser_ua) is None
+
+        # strict mode: blacklist * blocks everything not whitelisted
+        OpenaiBase.UA_BLACKLIST = ["*"]
+        OpenaiBase._compile_ua_patterns()
+        assert openai.validate_request_user_agent(my_app_ua) is None
+        with pytest.raises(HTTPException):
+            openai.validate_request_user_agent(browser_ua)
+
+        # missing/empty UA is blocked whenever filtering is enabled
+        OpenaiBase.UA_BLACKLIST = ["okhttp/*"]
+        OpenaiBase._compile_ua_patterns()
+        with pytest.raises(HTTPException):
+            openai.validate_request_user_agent("")
+
+        # matching is case-insensitive
+        with pytest.raises(HTTPException):
+            openai.validate_request_user_agent("OkHttp/5.0")
+
+        # patterns match the full UA string, not a prefix
+        OpenaiBase.UA_BLACKLIST = ["okhttp"]
+        OpenaiBase._compile_ua_patterns()
+        assert openai.validate_request_user_agent(my_app_ua) is None


### PR DESCRIPTION
New UA_WHITELIST / UA_BLACKLIST env vars (and --ua_whitelist / --ua_blacklist CLI flags) accept comma-separated glob patterns, e.g. allow okhttp/3.9.* while blocking okhttp/*.

Evaluation: whitelist match allows, then blacklist match blocks, otherwise allowed (add * to the blacklist for strict whitelist-only mode). Patterns match the full UA string, case-insensitively. Missing/empty User-Agent is rejected whenever filtering is enabled. Blocked requests receive a 403 identical to the HMAC-failure response, so clients get no hint that UA filtering exists.

The check runs before the HMAC body validation and only activates when at least one list is configured.